### PR TITLE
Fix usage of nil value

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -38,19 +38,21 @@ ESX.RegisterServerCallback('esx_skin:getPlayerSkin', function(source, cb)
 	MySQL.Async.fetchAll('SELECT skin FROM users WHERE identifier = @identifier', {
 		['@identifier'] = xPlayer.identifier
 	}, function(users)
-		local user = users[1]
-		local skin = nil
+		if users[1] ~= nil then
+			local user = users[1]
+			local skin = nil
 
-		local jobSkin = {
-			skin_male   = xPlayer.job.skin_male,
-			skin_female = xPlayer.job.skin_female
-		}
+			local jobSkin = {
+				skin_male   = xPlayer.job.skin_male,
+				skin_female = xPlayer.job.skin_female
+			}
 
-		if user.skin ~= nil then
-			skin = json.decode(user.skin)
+			if user.skin ~= nil then
+				skin = json.decode(user.skin)
+			end
+
+			cb(skin, jobSkin)
 		end
-
-		cb(skin, jobSkin)
 	end)
 end)
 

--- a/server/main.lua
+++ b/server/main.lua
@@ -5,12 +5,13 @@ TriggerEvent('esx:getSharedObject', function(obj) ESX = obj end)
 RegisterServerEvent('esx_skin:save')
 AddEventHandler('esx_skin:save', function(skin)
 	local xPlayer = ESX.GetPlayerFromId(source)
-
-	MySQL.Async.execute('UPDATE users SET `skin` = @skin WHERE identifier = @identifier',
-	{
-		['@skin']       = json.encode(skin),
-		['@identifier'] = xPlayer.identifier
-	})
+	if xPlayer ~= nil then
+		MySQL.Async.execute('UPDATE users SET `skin` = @skin WHERE identifier = @identifier',
+		{
+			['@skin']       = json.encode(skin),
+			['@identifier'] = xPlayer.identifier
+		})
+	end
 end)
 
 RegisterServerEvent('esx_skin:responseSaveSkin')
@@ -34,26 +35,28 @@ end)
 
 ESX.RegisterServerCallback('esx_skin:getPlayerSkin', function(source, cb)
 	local xPlayer = ESX.GetPlayerFromId(source)
+		
+	if xPlayer ~= nil then
+		MySQL.Async.fetchAll('SELECT skin FROM users WHERE identifier = @identifier', {
+			['@identifier'] = xPlayer.identifier
+		}, function(users)
+			if users[1] ~= nil then
+				local user = users[1]
+				local skin = nil
 
-	MySQL.Async.fetchAll('SELECT skin FROM users WHERE identifier = @identifier', {
-		['@identifier'] = xPlayer.identifier
-	}, function(users)
-		if users[1] ~= nil then
-			local user = users[1]
-			local skin = nil
+				local jobSkin = {
+					skin_male   = xPlayer.job.skin_male,
+					skin_female = xPlayer.job.skin_female
+				}
 
-			local jobSkin = {
-				skin_male   = xPlayer.job.skin_male,
-				skin_female = xPlayer.job.skin_female
-			}
+				if user.skin ~= nil then
+					skin = json.decode(user.skin)
+				end
 
-			if user.skin ~= nil then
-				skin = json.decode(user.skin)
+				cb(skin, jobSkin)
 			end
-
-			cb(skin, jobSkin)
-		end
-	end)
+		end)
+	end
 end)
 
 -- Commands


### PR DESCRIPTION
I  having this issue:

```
Error running call reference function for resource esx_skin: citizen:/scripting/lua/scheduler.lua:403: @esx_skin/server/main.lua:49: attempt to index a nil value (local 'user')
stack traceback:
        @esx_skin/server/main.lua:49: in upvalue 'ref'
        citizen:/scripting/lua/scheduler.lua:389: in function <citizen:/scripting/lua/scheduler.lua:388>
        [C]: in function 'xpcall'
        citizen:/scripting/lua/scheduler.lua:388: in function <citizen:/scripting/lua/scheduler.lua:387>
stack traceback:
        [C]: in function 'error'
        citizen:/scripting/lua/scheduler.lua:403: in function <citizen:/scripting/lua/scheduler.lua:372>
[91mError: Unhandled error in timer: Error: BUFFER_SHORTAGE
Error: BUFFER_SHORTAGE
    at n.e [as reserve] (citizen:/scripting/v8/msgpack.js:29:12766)
    at h (citizen:/scripting/v8/msgpack.js:29:15761)
    at n.r [as decode] (citizen:/scripting/v8/msgpack.js:29:13908)
    at n.fetch (citizen:/scripting/v8/msgpack.js:29:6972)
    at n.u [as read] (citizen:/scripting/v8/msgpack.js:29:12076)
    at Object.n [as decode] (citizen:/scripting/v8/msgpack.js:29:7097)
    at unpack (citizen:/scripting/v8/main.js:20:33)
    at citizen:/scripting/v8/main.js:51:20
    at setImmediate (mysql-async.js:4962:9)
    at Object.callback (citizen:/scripting/v8/timer.js:96:21)[0m
```

This will fix it